### PR TITLE
Reduce nuisance workflow runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "eventlet"
-
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **test**: switch `on: [push, pull_request]` → `push: branches: [main]` + `pull_request`, so PR commits don't fire both `push` and `pull_request` runs of the same SHA.
- **dependabot.yml**: drop pip ecosystem. Repo contains only a Dockerfile and LICENSE, so the pip ecosystem has been failing daily with `dependency_file_not_found: "No files found in /"`.

## Test plan

- [ ] Only one `test` run is created per PR commit.
- [ ] No new `Dependabot Updates` failures appear after merge.